### PR TITLE
Made public struct and constants, fixed dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license-file = "LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hdk = "0.0.42-alpha3"
-serde_derive = "1.0.89"
-serde_json = { version = "=1.0.39", features = ["preserve_order"] }
-holochain_json_derive = "=0.0.15"
-serde = "=1.0.89"
+hdk = { git = "https://github.com/holochain/holochain-rust" }
+serde_derive = "^1.0"
+serde_json = { version = "^1.0", features = ["preserve_order"] }
+holochain_json_derive = "^0.0"
+serde = "^1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@ use hdk::prelude::*;
 pub mod defs;
 pub use defs::*;
 
-const ROOT_ANCHOR: &'static str = concat!("holochain_anchors", "::", "root_anchor");
+pub const ROOT_ANCHOR: &'static str = concat!("holochain_anchors", "::", "root_anchor");
 pub const ANCHOR_TYPE: &'static str = concat!("holochain_anchors", "::", "Anchor");
-const ANCHOR_LINK_TYPE: &'static str = concat!("holochain_anchors", "::", "anchor_link");
+pub const ANCHOR_LINK_TYPE: &'static str = concat!("holochain_anchors", "::", "anchor_link");
 
 #[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
-struct Anchor {
+pub struct Anchor {
     anchor_type: String,
     anchor_text: Option<String>,
 }
@@ -81,13 +81,13 @@ fn root_anchor() -> ZomeApiResult<Address> {
 }
 
 impl Anchor {
-    fn new(anchor_type: String, anchor_text: Option<String>) -> Self {
+    pub fn new(anchor_type: String, anchor_text: Option<String>) -> Self {
         Anchor {
             anchor_type,
             anchor_text,
         }
     }
-    fn entry(self) -> Entry {
+    pub fn entry(self) -> Entry {
         Entry::App(ANCHOR_TYPE.into(), self.into())
     }
 }


### PR DESCRIPTION
I tested to build a DNA with `0.0.43-alpha3` pointing to this new version locally and it works.

I had to change the HDK dependencies to `hdk = { git = "https://github.com/holochain/holochain-rust" }`.

Having the HDK dependencies with `*` or `0.0` does not work... I think this is because cargo does not understand the `alpha3` in holochain crates names, but @freesig you have more experience with this, I can change that dependency if you want.