### PR TITLE
Relax serialisation dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "LICENSE"
 
 [dependencies]
 hdk = "0.0.47-alpha1"
-serde_derive = "1.0.104"
-serde_json = { version = "=1.0.47", features = ["preserve_order"] }
-holochain_json_derive = "=0.0.23"
-serde = "=1.0.104"
+serde_derive = "^1.0"
+serde_json = { version = "^1.0", features = ["preserve_order"] }
+holochain_json_derive = "^0.0"
+serde = "^1.0"


### PR DESCRIPTION
Pinning `serde*` and `holochain_json_derive` dependencies to a specific patch number causes downstream projects based on the standard zome templates (whose version numbers are relaxed to `serde*` ^1.0 and `holochain_json_derive` ^0.0) to double-import these packages, causing DNA bloat. (At time of writing, this means that `holochain_json_derive` 0.0.23 and 0.0.30 are both imported on any zome that relies on `holochain_anchors`). This PR brings this library in line with those downstream projects' expectations.