### PR TITLE
Develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/holochain-anchors"
 license-file = "LICENSE"
 
 [dependencies]
-hdk = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }
+hdk = "=0.0.48-alpha1"
 serde_derive = "1.0.104"
 serde_json = { version = "=1.0.47", features = ["preserve_order"] }
 holochain_json_derive = "=0.0.23"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,22 @@ pub fn get_anchors() -> ZomeApiResult<Vec<Address>> {
     .to_owned())
 }
 
+/**
+ * Get all anchors of the specified type
+ */
+pub fn get_anchors_of_type(anchor_type: String) -> ZomeApiResult<Vec<Address>> {
+    let anchor_entry = Anchor::new(anchor_type.clone(), None).entry();
+    let parent_anchor_address = anchor_entry.address();
+
+    let links = hdk::get_links(
+        &parent_anchor_address,
+        LinkMatch::Exactly(ANCHOR_LINK_TYPE),
+        LinkMatch::Any,
+    )?;
+
+    Ok(links.addresses())
+}
+
 fn check_parent(anchor_type: String) -> ZomeApiResult<Address> {
     let anchor_type_entry = Anchor::new(anchor_type.clone(), None).entry();
     let anchor_type_address = anchor_type_entry.address();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use hdk::{
     error::ZomeApiResult,
     holochain_core_types::entry::Entry,
     holochain_persistence_api::cas::content::{Address, AddressableContent},
+    holochain_wasm_utils::api_serialization::get_links::LinksResult,
 };
 
 use serde_derive::{Deserialize, Serialize};
@@ -60,7 +61,7 @@ pub fn get_anchors() -> ZomeApiResult<Vec<Address>> {
 /**
  * Get all anchors of the specified type
  */
-pub fn get_anchors_of_type(anchor_type: String) -> ZomeApiResult<Vec<Address>> {
+pub fn get_anchors_of_type(anchor_type: String) -> ZomeApiResult<Vec<LinksResult>> {
     let anchor_entry = Anchor::new(anchor_type.clone(), None).entry();
     let parent_anchor_address = anchor_entry.address();
 
@@ -70,7 +71,7 @@ pub fn get_anchors_of_type(anchor_type: String) -> ZomeApiResult<Vec<Address>> {
         LinkMatch::Any,
     )?;
 
-    Ok(links.addresses())
+    Ok(links.links())
 }
 
 fn check_parent(anchor_type: String) -> ZomeApiResult<Address> {


### PR DESCRIPTION
- Updated to 0.0.48-alpha1 to prevent compilation error
- Added `get_anchors_of_type` to retrieve the list of anchors addresses of the given type

Pinging @zippy @freesig @philipbeadle @pdaoust