### PR TITLE
Update 0.0.48 alpha1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ documentation = "https://docs.rs/holochain-anchors"
 license-file = "LICENSE"
 
 [dependencies]
-hdk = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }
+hdk = "=0.0.48-alpha1"
+hdk_proc_macros = "=0.0.48-alpha1"
+holochain_wasm_utils = "=0.0.48-alpha1"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 holochain_json_derive = "0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ license-file = "LICENSE"
 
 [dependencies]
 hdk = "=0.0.48-alpha1"
-hdk_proc_macros = "=0.0.48-alpha1"
-holochain_wasm_utils = "=0.0.48-alpha1"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 holochain_json_derive = "0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "LICENSE"
 
 [dependencies]
 hdk = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }
-serde_derive = "1.0.104"
-serde_json = { version = "=1.0.47", features = ["preserve_order"] }
-holochain_json_derive = "=0.0.23"
-serde = "=1.0.104"
+serde_derive = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
+holochain_json_derive = "0.0"
+serde = "1.0"


### PR DESCRIPTION
Required for 'blessing' Holonix v0.0.74 with Holochain v0.0.48. I also relaxed the serde dependencies, to make it match the Cargo.toml that the default zome templates generate.