### PR TITLE
Re-apply #20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ documentation = "https://docs.rs/holochain-anchors"
 license-file = "LICENSE"
 
 [dependencies]
-hdk = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }
-serde_derive = "1.0.104"
-serde_json = { version = "=1.0.47", features = ["preserve_order"] }
-holochain_json_derive = "=0.0.23"
-serde = "=1.0.104"
+hdk = "=0.0.48-alpha1"
+serde_derive = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
+holochain_json_derive = "0.0"
+serde = "1.0"


### PR DESCRIPTION
Reverts holochain/holochain-anchors#21 which reverted holochain/holochain-anchors#20 . I jumped the gun and updated the HDK dependency to 0.0.48, when actually we should be doing that only after the version of Holonix that contains that HDK is blessed.

So what this does is re-apply #20 