### PR TITLE
update hdk crate to v0.0.49-alpha1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/holochain-anchors"
 license-file = "LICENSE"
 
 [dependencies]
-hdk = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }
+hdk = "=0.0.49-alpha1"
 serde_derive = "1.0.104"
 serde_json = { version = "=1.0.47", features = ["preserve_order"] }
 holochain_json_derive = "=0.0.23"


### PR DESCRIPTION
- points the hdk crate to the updated holochain version, v0.0.49-alpha1